### PR TITLE
application: Correct some grammar errors

### DIFF
--- a/po/pardus-software.pot
+++ b/po/pardus-software.pot
@@ -284,7 +284,7 @@ msgid ""
 msgstr ""
 
 #: ui/MainWindow.glade:5024
-msgid "Your Name :"
+msgid "Your Name:"
 msgstr ""
 
 #: ui/MainWindow.glade:5038
@@ -292,7 +292,7 @@ msgid "Write your name"
 msgstr ""
 
 #: ui/MainWindow.glade:5064
-msgid "Your Comment :"
+msgid "Your Comment:"
 msgstr ""
 
 #: ui/MainWindow.glade:5125 ui/MainWindow.glade:7312
@@ -457,11 +457,11 @@ msgid "Category (*)"
 msgstr ""
 
 #: ui/MainWindow.glade:6892
-msgid "Description ( Turkish ) (*)"
+msgid "Description (Turkish) (*)"
 msgstr ""
 
 #: ui/MainWindow.glade:6950
-msgid "Description ( English ) (*)"
+msgid "Description (English) (*)"
 msgstr ""
 
 #: ui/MainWindow.glade:7008
@@ -477,7 +477,7 @@ msgid "Website (*)"
 msgstr ""
 
 #: ui/MainWindow.glade:7145
-msgid "Icon ( svg )"
+msgid "Icon (svg)"
 msgstr ""
 
 #: ui/MainWindow.glade:7158
@@ -501,7 +501,7 @@ msgid "* Required fields"
 msgstr ""
 
 #: ui/MainWindow.glade:7365
-msgid "Your application suggestion has been successfully submitted. "
+msgid "Your application suggestion has been successfully submitted."
 msgstr ""
 
 #: ui/MainWindow.glade:7414
@@ -535,7 +535,7 @@ msgid "Go to Homepage"
 msgstr ""
 
 #: ui/MainWindow.glade:7610
-msgid "You can check the terminal output below. "
+msgid "You can check the terminal output below."
 msgstr ""
 
 #: ui/MainWindow.glade:7639
@@ -588,27 +588,27 @@ msgid "description"
 msgstr ""
 
 #: ui/MainWindow.glade:8533
-msgid "Packages to remove :"
+msgid "Packages to remove:"
 msgstr ""
 
 #: ui/MainWindow.glade:8597
-msgid "Packages to install :"
+msgid "Packages to install:"
 msgstr ""
 
 #: ui/MainWindow.glade:8661
-msgid "Broken packages :"
+msgid "Broken packages:"
 msgstr ""
 
 #: ui/MainWindow.glade:8725
-msgid "Disk space to be freed :"
+msgid "Disk space to be freed:"
 msgstr ""
 
 #: ui/MainWindow.glade:8789
-msgid "Download size :"
+msgid "Download size:"
 msgstr ""
 
 #: ui/MainWindow.glade:8853
-msgid "Required disk space :"
+msgid "Required disk space:"
 msgstr ""
 
 #: ui/MainWindow.glade:8917 ui/MainWindow.glade:8990
@@ -627,7 +627,7 @@ msgstr ""
 msgid ""
 "- Application uninstalling process is only valid for applications that the "
 "package manager (apt) supports.\n"
-"<i><small>( installed from repositories or via the .deb package )</small></"
+"<i><small>(installed from repositories or via the .deb package)</small></"
 "i>\n"
 "\n"
 "- For applications installed using tools such as Flatpak, Snap, Wine, you "
@@ -979,11 +979,11 @@ msgid "is empty"
 msgstr ""
 
 #: src/MainWindow.py:4897
-msgid "Description ( Turkish )"
+msgid "Description (Turkish)"
 msgstr ""
 
 #: src/MainWindow.py:4900
-msgid "Description ( English )"
+msgid "Description (English)"
 msgstr ""
 
 #: src/MainWindow.py:4918
@@ -1167,27 +1167,27 @@ msgid "Downloading"
 msgstr ""
 
 #: src/MainWindow.py:5568
-msgid " | Removed : 100 %"
+msgid " | Removed: 100%"
 msgstr ""
 
 #: src/MainWindow.py:5570
-msgid " | Installed : 100 %"
+msgid " | Installed: 100%"
 msgstr ""
 
 #: src/MainWindow.py:5572
-msgid " |  Not Completed"
+msgid " | Not Completed"
 msgstr ""
 
 #: src/MainWindow.py:5574
-msgid "<b><span color='red'>Connection Error !</span></b>"
+msgid "<b><span color='red'>Connection Error!</span></b>"
 msgstr ""
 
 #: src/MainWindow.py:5576
-msgid "<b><span color='red'>Dpkg Lock Error !</span></b>"
+msgid "<b><span color='red'>Dpkg Lock Error!</span></b>"
 msgstr ""
 
 #: src/MainWindow.py:5578
-msgid "<b><span color='red'>Dpkg Interrupt Error !</span></b>"
+msgid "<b><span color='red'>Dpkg Interrupt Error!</span></b>"
 msgstr ""
 
 #: src/MainWindow.py:5637
@@ -1226,5 +1226,5 @@ msgid "You can now update package manager cache."
 msgstr ""
 
 #: src/MainWindow.py:5960
-msgid "An error occurred while updating the package cache. Exit Code : "
+msgid "An error occurred while updating the package cache. Exit Code: "
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -298,16 +298,16 @@ msgstr ""
 "adicionar um comentário se quiser."
 
 #: ui/MainWindow.glade:5033
-msgid "Your Name :"
-msgstr "O seu nome :"
+msgid "Your Name:"
+msgstr "O seu nome:"
 
 #: ui/MainWindow.glade:5047
 msgid "Write your name"
 msgstr "Escreva o seu nome"
 
 #: ui/MainWindow.glade:5073
-msgid "Your Comment :"
-msgstr "O seu comentário :"
+msgid "Your Comment:"
+msgstr "O seu comentário:"
 
 #: ui/MainWindow.glade:5134 ui/MainWindow.glade:7313
 msgid "Send"
@@ -474,19 +474,19 @@ msgid "Application Name"
 msgstr "Nome da aplicação"
 
 #: ui/MainWindow.glade:6901 src/MainWindow.py:4781
-msgid "Description ( Turkish )"
-msgstr "Descrição ( Turco )"
+msgid "Description (Turkish)"
+msgstr "Descrição (Turco)"
 
 #: ui/MainWindow.glade:6959 src/MainWindow.py:4784
-msgid "Description ( English )"
-msgstr "Descrição ( Inglês )"
+msgid "Description (English)"
+msgstr "Descrição (Inglês)"
 
 #: ui/MainWindow.glade:7056 src/MainWindow.py:4790
 msgid "Copyright Text"
 msgstr "Texto de direitos de autor"
 
 #: ui/MainWindow.glade:7154
-msgid "Icon ( svg )"
+msgid "Icon (svg)"
 msgstr "Ícone (svg)"
 
 #: ui/MainWindow.glade:7167
@@ -502,8 +502,8 @@ msgid "Is the application available in Pardus repositories?"
 msgstr "A aplicação está disponível nos repositórios do Pardus?"
 
 #: ui/MainWindow.glade:7366
-msgid "Your application suggestion has been successfully submitted. "
-msgstr "A sua sugestão de aplicação foi submetida com sucesso. "
+msgid "Your application suggestion has been successfully submitted."
+msgstr "A sua sugestão de aplicação foi submetida com sucesso."
 
 #: ui/MainWindow.glade:7415
 msgid ""
@@ -545,8 +545,8 @@ msgid "Go to Homepage"
 msgstr "Ir para a página inicial"
 
 #: ui/MainWindow.glade:7611
-msgid "You can check the terminal output below. "
-msgstr "Pode verificar o resultado do terminal abaixo. "
+msgid "You can check the terminal output below."
+msgstr "Pode verificar o resultado do terminal abaixo."
 
 #: ui/MainWindow.glade:7640
 msgid "The error in the package manager could not be fixed."
@@ -587,28 +587,28 @@ msgid "description"
 msgstr "descrição"
 
 #: ui/MainWindow.glade:8321
-msgid "Packages to remove :"
-msgstr "Pacotes a remover :"
+msgid "Packages to remove:"
+msgstr "Pacotes a remover:"
 
 #: ui/MainWindow.glade:8385
-msgid "Packages to install :"
-msgstr "Pacotes a instalar :"
+msgid "Packages to install:"
+msgstr "Pacotes a instalar:"
 
 #: ui/MainWindow.glade:8449
-msgid "Broken packages :"
-msgstr "Pacotes quebrados :"
+msgid "Broken packages:"
+msgstr "Pacotes quebrados:"
 
 #: ui/MainWindow.glade:8513
-msgid "Disk space to be freed :"
-msgstr "Espaço em disco a ser libertado :"
+msgid "Disk space to be freed:"
+msgstr "Espaço em disco a ser libertado:"
 
 #: ui/MainWindow.glade:8577
-msgid "Download size :"
-msgstr "Tamanho da transferência :"
+msgid "Download size:"
+msgstr "Tamanho da transferência:"
 
 #: ui/MainWindow.glade:8641
-msgid "Required disk space :"
-msgstr "Espaço necessário em disco :"
+msgid "Required disk space:"
+msgstr "Espaço necessário em disco:"
 
 #: ui/MainWindow.glade:8705 ui/MainWindow.glade:8778
 msgid "Back"
@@ -626,7 +626,7 @@ msgstr "<b><big>Não foi possível desinstalar a aplicação.</big></b>"
 msgid ""
 "- Application uninstalling process is only valid for applications that the "
 "package manager (apt) supports.\n"
-"<i><small>( installed from repositories or via the .deb package )</small></"
+"<i><small>(installed from repositories or via the .deb package)</small></"
 "i>\n"
 "\n"
 "- For applications installed using tools such as Flatpak, Snap, Wine, you "
@@ -1167,28 +1167,28 @@ msgid "Downloading"
 msgstr "A transferir"
 
 #: src/MainWindow.py:5454
-msgid " | Removed : 100 %"
-msgstr " | Removido : 100 %"
+msgid " | Removed: 100%"
+msgstr " | Removido : 100%"
 
 #: src/MainWindow.py:5456
-msgid " | Installed : 100 %"
-msgstr " | Instalado : 100 %"
+msgid " | Installed: 100%"
+msgstr " | Instalado : 100%"
 
 #: src/MainWindow.py:5458
-msgid " |  Not Completed"
-msgstr " |  Não concluído"
+msgid " | Not Completed"
+msgstr " | Não concluído"
 
 #: src/MainWindow.py:5460
-msgid "<b><span color='red'>Connection Error !</span></b>"
-msgstr "<b><span color='red'>Erro de ligação !</span></b>"
+msgid "<b><span color='red'>Connection Error!</span></b>"
+msgstr "<b><span color='red'>Erro de ligação!</span></b>"
 
 #: src/MainWindow.py:5462
-msgid "<b><span color='red'>Dpkg Lock Error !</span></b>"
-msgstr "<b><span color='red'>Erro de bloqueio do dpkg !</span></b>"
+msgid "<b><span color='red'>Dpkg Lock Error!</span></b>"
+msgstr "<b><span color='red'>Erro de bloqueio do dpkg!</span></b>"
 
 #: src/MainWindow.py:5464
-msgid "<b><span color='red'>Dpkg Interrupt Error !</span></b>"
-msgstr "<b><span color='red'>Erro de interrupção do dpkg !</span></b>"
+msgid "<b><span color='red'>Dpkg Interrupt Error!</span></b>"
+msgstr "<b><span color='red'>Erro de interrupção do dpkg!</span></b>"
 
 #: src/MainWindow.py:5523
 msgid ""
@@ -1231,8 +1231,8 @@ msgid "You can now update package manager cache."
 msgstr "Pode agora atualizar a cache do gestor de pacotes."
 
 #: src/MainWindow.py:5827
-msgid "An error occurred while updating the package cache. Exit Code : "
-msgstr "Ocorreu um erro ao atualizar a cache dos pacotes. Resultado : "
+msgid "An error occurred while updating the package cache. Exit Code: "
+msgstr "Ocorreu um erro ao atualizar a cache dos pacotes. Resultado: "
 
 #~ msgid "Most Rated Apps"
 #~ msgstr "Aplicações mais avaliadas"

--- a/po/tr.po
+++ b/po/tr.po
@@ -304,16 +304,16 @@ msgstr ""
 "ekleyebilirsiniz."
 
 #: ui/MainWindow.glade:5024
-msgid "Your Name :"
-msgstr "Adınız :"
+msgid "Your Name:"
+msgstr "Adınız:"
 
 #: ui/MainWindow.glade:5038
 msgid "Write your name"
 msgstr "Adınızı yazınız"
 
 #: ui/MainWindow.glade:5064
-msgid "Your Comment :"
-msgstr "Yorumunuz :"
+msgid "Your Comment:"
+msgstr "Yorumunuz:"
 
 #: ui/MainWindow.glade:5125 ui/MainWindow.glade:7312
 msgid "Send"
@@ -483,12 +483,12 @@ msgid "Category (*)"
 msgstr "Kategori (*)"
 
 #: ui/MainWindow.glade:6892
-msgid "Description ( Turkish ) (*)"
-msgstr "Açıklama ( Türkçe ) (*)"
+msgid "Description (Turkish) (*)"
+msgstr "Açıklama (Türkçe) (*)"
 
 #: ui/MainWindow.glade:6950
-msgid "Description ( English ) (*)"
-msgstr "Açıklama ( İngilizce ) (*)"
+msgid "Description (English) (*)"
+msgstr "Açıklama (İngilizce) (*)"
 
 #: ui/MainWindow.glade:7008
 msgid "License (*)"
@@ -503,8 +503,8 @@ msgid "Website (*)"
 msgstr "Web sitesi (*)"
 
 #: ui/MainWindow.glade:7145
-msgid "Icon ( svg )"
-msgstr "İkon ( svg )"
+msgid "Icon (svg)"
+msgstr "İkon (svg)"
 
 #: ui/MainWindow.glade:7158
 msgid "Select Icon"
@@ -527,7 +527,7 @@ msgid "* Required fields"
 msgstr "* Zorunlu alanlar"
 
 #: ui/MainWindow.glade:7365
-msgid "Your application suggestion has been successfully submitted. "
+msgid "Your application suggestion has been successfully submitted."
 msgstr "Uygulama öneriniz başarıyla gönderildi."
 
 #: ui/MainWindow.glade:7414
@@ -571,7 +571,7 @@ msgid "Go to Homepage"
 msgstr "Ana Sayfaya Git"
 
 #: ui/MainWindow.glade:7610
-msgid "You can check the terminal output below. "
+msgid "You can check the terminal output below."
 msgstr "Aşağıdaki terminal çıktısını kontrol edebilirsiniz."
 
 #: ui/MainWindow.glade:7639
@@ -626,28 +626,28 @@ msgid "description"
 msgstr "açıklama"
 
 #: ui/MainWindow.glade:8533
-msgid "Packages to remove :"
-msgstr "Kaldırılacak paketler :"
+msgid "Packages to remove:"
+msgstr "Kaldırılacak paketler:"
 
 #: ui/MainWindow.glade:8597
-msgid "Packages to install :"
-msgstr "Yüklenecek paketler :"
+msgid "Packages to install:"
+msgstr "Kurulacak paketler:"
 
 #: ui/MainWindow.glade:8661
-msgid "Broken packages :"
-msgstr "Bozuk paketler :"
+msgid "Broken packages:"
+msgstr "Bozuk paketler:"
 
 #: ui/MainWindow.glade:8725
-msgid "Disk space to be freed :"
-msgstr "Boşalacak disk alanı :"
+msgid "Disk space to be freed:"
+msgstr "Boşalacak disk alanı:"
 
 #: ui/MainWindow.glade:8789
-msgid "Download size :"
-msgstr "İndirme boyutu :"
+msgid "Download size:"
+msgstr "İndirme boyutu:"
 
 #: ui/MainWindow.glade:8853
-msgid "Required disk space :"
-msgstr "Gerekli disk alanı :"
+msgid "Required disk space:"
+msgstr "Gerekli disk alanı:"
 
 #: ui/MainWindow.glade:8917 ui/MainWindow.glade:8990
 msgid "Back"
@@ -1029,12 +1029,12 @@ msgid "is empty"
 msgstr "boş"
 
 #: src/MainWindow.py:4897
-msgid "Description ( Turkish )"
-msgstr "Açıklama ( Türkçe )"
+msgid "Description (Turkish)"
+msgstr "Açıklama (Türkçe)"
 
 #: src/MainWindow.py:4900
-msgid "Description ( English )"
-msgstr "Açıklama ( İngilizce )"
+msgid "Description (English)"
+msgstr "Açıklama (İngilizce)"
 
 #: src/MainWindow.py:4918
 msgid "Mail"
@@ -1152,7 +1152,7 @@ msgid ""
 "GNOME comments are pulled from <a href='https://odrs.gnome.org'>GNOME ODRS</"
 "a>."
 msgstr ""
-"GNOME yorumları <a href='https://odrs.gnome.org'>GNOME ODRS</a> ' den "
+"GNOME yorumları <a href='https://odrs.gnome.org'>GNOME ODRS</a>ʼden "
 "çekilmektedir."
 
 #: src/MainWindow.py:5020
@@ -1226,28 +1226,28 @@ msgid "Downloading"
 msgstr "İndiriliyor"
 
 #: src/MainWindow.py:5568
-msgid " | Removed : 100 %"
-msgstr " | Kaldırıldı : 100 %"
+msgid " | Removed: 100%"
+msgstr " | Kaldırıldı: 100%"
 
 #: src/MainWindow.py:5570
-msgid " | Installed : 100 %"
-msgstr " | Yüklendi : 100 %"
+msgid " | Installed: 100%"
+msgstr " | Kuruldu: 100%"
 
 #: src/MainWindow.py:5572
-msgid " |  Not Completed"
-msgstr " |  Tamamlanamadı"
+msgid " | Not Completed"
+msgstr " | Tamamlanamadı"
 
 #: src/MainWindow.py:5574
-msgid "<b><span color='red'>Connection Error !</span></b>"
-msgstr "<b><span color='red'>Bağlantı Hatası !</span></b>"
+msgid "<b><span color='red'>Connection Error!</span></b>"
+msgstr "<b><span color='red'>Bağlantı Hatası!</span></b>"
 
 #: src/MainWindow.py:5576
-msgid "<b><span color='red'>Dpkg Lock Error !</span></b>"
-msgstr "<b><span color='red'>Dpkg Kilitleme Hatası !</span></b>"
+msgid "<b><span color='red'>Dpkg Lock Error!</span></b>"
+msgstr "<b><span color='red'>Dpkg Kilitleme Hatası!</span></b>"
 
 #: src/MainWindow.py:5578
-msgid "<b><span color='red'>Dpkg Interrupt Error !</span></b>"
-msgstr "<b><span color='red'>Dpkg Kesinti Hatası !</span></b>"
+msgid "<b><span color='red'>Dpkg Interrupt Error!</span></b>"
+msgstr "<b><span color='red'>Dpkg Kesinti Hatası!</span></b>"
 
 #: src/MainWindow.py:5637
 msgid ""
@@ -1288,8 +1288,8 @@ msgid "You can now update package manager cache."
 msgstr "Artık paket yöneticisi önbelleğini güncelleyebilirsiniz."
 
 #: src/MainWindow.py:5960
-msgid "An error occurred while updating the package cache. Exit Code : "
-msgstr "Paket önbelleği güncellenirken bir hata oluştu. Çıkış Kodu :"
+msgid "An error occurred while updating the package cache. Exit Code: "
+msgstr "Paket önbelleği güncellenirken bir hata oluştu. Çıkış Kodu:"
 
 #~ msgid "Most Rated Apps"
 #~ msgstr "Oylaması En Yüksek Uygulamalar"

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -4894,10 +4894,10 @@ class MainWindow(object):
             return False, _("Category")
 
         if self.sug_desc_tr.strip() == "":
-            return False, _("Description ( Turkish )")
+            return False, _("Description (Turkish)")
 
         if self.sug_desc_en.strip() == "":
-            return False, _("Description ( English )")
+            return False, _("Description (English)")
 
         if self.sug_license.strip() == "":
             return False, _("License")
@@ -5565,17 +5565,17 @@ class MainWindow(object):
             if not self.error:
                 if status == 0:
                     if self.isinstalled:
-                        self.progresstextlabel.set_text(self.actionedappname + _(" | Removed : 100 %"))
+                        self.progresstextlabel.set_text(self.actionedappname + _(" | Removed: 100%"))
                     else:
-                        self.progresstextlabel.set_text(self.actionedappname + _(" | Installed : 100 %"))
+                        self.progresstextlabel.set_text(self.actionedappname + _(" | Installed: 100%"))
                 else:
-                    self.progresstextlabel.set_text(self.actionedappname + _(" | " + " Not Completed"))
+                    self.progresstextlabel.set_text(self.actionedappname + _(" | Not Completed"))
             else:
-                self.errormessage = _("<b><span color='red'>Connection Error !</span></b>")
+                self.errormessage = _("<b><span color='red'>Connection Error!</span></b>")
                 if self.dpkglockerror:
-                    self.errormessage = _("<b><span color='red'>Dpkg Lock Error !</span></b>")
+                    self.errormessage = _("<b><span color='red'>Dpkg Lock Error!</span></b>")
                 elif self.dpkgconferror:
-                    self.errormessage = _("<b><span color='red'>Dpkg Interrupt Error !</span></b>")
+                    self.errormessage = _("<b><span color='red'>Dpkg Interrupt Error!</span></b>")
 
             cachestatus = self.Package.updatecache()
 
@@ -5601,7 +5601,7 @@ class MainWindow(object):
                     self.raction.set_sensitive(True)
 
             self.topspinner.stop()
-            print("Exit Code : {}".format(status))
+            print("Exit Code: {}".format(status))
 
             self.inprogress = False
 
@@ -5957,10 +5957,10 @@ class MainWindow(object):
                 self.dAptUpdateBox.set_visible(True)
                 self.dAptUpdateInfoLabel.set_visible(True)
                 self.dAptUpdateInfoLabel.set_markup("<span color='red'>{}{}</span>".format(
-                    _("An error occurred while updating the package cache. Exit Code : "), status))
+                    _("An error occurred while updating the package cache. Exit Code: "), status))
             self.aptupdateclicked = False
 
-        print("SysProcess Exit Code : {}".format(status))
+        print("SysProcess Exit Code: {}".format(status))
 
     def startAptUpdateProcess(self, params):
         pid, stdin, stdout, stderr = GLib.spawn_async(params, flags=GLib.SpawnFlags.DO_NOT_REAP_CHILD,

--- a/ui/MainWindow.glade
+++ b/ui/MainWindow.glade
@@ -5021,7 +5021,7 @@ This application served from Pardus non-free package repositories, so that the O
                                                             <property name="width-request">175</property>
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Your Name :</property>
+                                                            <property name="label" translatable="yes">Your Name:</property>
                                                             </object>
                                                             <packing>
                                                             <property name="expand">False</property>
@@ -5061,7 +5061,7 @@ This application served from Pardus non-free package repositories, so that the O
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="valign">center</property>
-                                                            <property name="label" translatable="yes">Your Comment :</property>
+                                                            <property name="label" translatable="yes">Your Comment:</property>
                                                             </object>
                                                             <packing>
                                                             <property name="expand">False</property>
@@ -6889,7 +6889,7 @@ This application served from Pardus non-free package repositories, so that the O
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
-                                                <property name="label" translatable="yes">Description ( Turkish ) (*)</property>
+                                                <property name="label" translatable="yes">Description (Turkish) (*)</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -6947,7 +6947,7 @@ This application served from Pardus non-free package repositories, so that the O
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
-                                                <property name="label" translatable="yes">Description ( English ) (*)</property>
+                                                <property name="label" translatable="yes">Description (English) (*)</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -7142,7 +7142,7 @@ This application served from Pardus non-free package repositories, so that the O
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
-                                                <property name="label" translatable="yes">Icon ( svg )</property>
+                                                <property name="label" translatable="yes">Icon (svg)</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -7362,7 +7362,7 @@ This application served from Pardus non-free package repositories, so that the O
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="label" translatable="yes">Your application suggestion has been successfully submitted. </property>
+                                            <property name="label" translatable="yes">Your application suggestion has been successfully submitted.</property>
                                             <attributes>
                                               <attribute name="weight" value="bold"/>
                                             </attributes>
@@ -7607,7 +7607,7 @@ Use with caution. Are you sure you want to continue?</property>
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">You can check the terminal output below. </property>
+                                    <property name="label" translatable="yes">You can check the terminal output below.</property>
                                     <attributes>
                                       <attribute name="weight" value="thin"/>
                                     </attributes>
@@ -8530,7 +8530,7 @@ Use with caution. Are you sure you want to continue?</property>
                                                           <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Packages to remove :</property>
+                                                            <property name="label" translatable="yes">Packages to remove:</property>
                                                             <attributes>
                                                             <attribute name="weight" value="bold"/>
                                                             </attributes>
@@ -8594,7 +8594,7 @@ Use with caution. Are you sure you want to continue?</property>
                                                           <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Packages to install :</property>
+                                                            <property name="label" translatable="yes">Packages to install:</property>
                                                             <attributes>
                                                             <attribute name="weight" value="bold"/>
                                                             </attributes>
@@ -8658,7 +8658,7 @@ Use with caution. Are you sure you want to continue?</property>
                                                           <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Broken packages :</property>
+                                                            <property name="label" translatable="yes">Broken packages:</property>
                                                             <attributes>
                                                             <attribute name="weight" value="bold"/>
                                                             </attributes>
@@ -8722,7 +8722,7 @@ Use with caution. Are you sure you want to continue?</property>
                                                           <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Disk space to be freed :</property>
+                                                            <property name="label" translatable="yes">Disk space to be freed:</property>
                                                             <attributes>
                                                             <attribute name="weight" value="bold"/>
                                                             </attributes>
@@ -8786,7 +8786,7 @@ Use with caution. Are you sure you want to continue?</property>
                                                           <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Download size :</property>
+                                                            <property name="label" translatable="yes">Download size:</property>
                                                             <attributes>
                                                             <attribute name="weight" value="bold"/>
                                                             </attributes>
@@ -8850,7 +8850,7 @@ Use with caution. Are you sure you want to continue?</property>
                                                           <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
-                                                            <property name="label" translatable="yes">Required disk space :</property>
+                                                            <property name="label" translatable="yes">Required disk space:</property>
                                                             <attributes>
                                                             <attribute name="weight" value="bold"/>
                                                             </attributes>
@@ -9115,7 +9115,7 @@ Use with caution. Are you sure you want to continue?</property>
                                     <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="label" translatable="yes">- Application uninstalling process is only valid for applications that the package manager (apt) supports.
-&lt;i&gt;&lt;small&gt;( installed from repositories or via the .deb package )&lt;/small&gt;&lt;/i&gt;
+&lt;i&gt;&lt;small&gt;(installed from repositories or via the .deb package)&lt;/small&gt;&lt;/i&gt;
 
 - For applications installed using tools such as Flatpak, Snap, Wine, you can review the removal instructions of the relevant application.</property>
                                     <property name="use-markup">True</property>


### PR DESCRIPTION
- Do not use space before colon (:).
- Do not use space before exclamation mark (!).
- Remove trilling spaces.