### PR TITLE
Change "apt" with "apt-get" command

### DIFF
--- a/src/Actions.py
+++ b/src/Actions.py
@@ -24,33 +24,33 @@ def main():
 
     def install(packages):
         packagelist = packages.split(" ")
-        subprocess.call(["apt", "install", "-yq", "-o", "APT::Status-Fd=2"] + packagelist,
+        subprocess.call(["apt-get", "install", "-yq", "-o", "APT::Status-Fd=2"] + packagelist,
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def reinstall(debianpackage):
-        subprocess.call(["apt", "install", "--reinstall", debianpackage, "-yq", "-o", "APT::Status-Fd=2"],
+        subprocess.call(["apt-get", "install", "--reinstall", debianpackage, "-yq", "-o", "APT::Status-Fd=2"],
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def remove(packages):
         packagelist = packages.split(" ")
-        subprocess.call(["apt", "remove", "--purge", "-yq", "-o", "APT::Status-Fd=2"] + packagelist,
+        subprocess.call(["apt-get", "remove", "--purge", "-yq", "-o", "APT::Status-Fd=2"] + packagelist,
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def downgrade(packagename):
-        subprocess.call(["apt", "install", "--allow-downgrades", packagename, "-yq", "-o", "APT::Status-Fd=2"],
+        subprocess.call(["apt-get", "install", "--allow-downgrades", packagename, "-yq", "-o", "APT::Status-Fd=2"],
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def update():
-        subprocess.call(["apt", "update", "-o", "APT::Status-Fd=2"],
+        subprocess.call(["apt-get", "update", "-o", "APT::Status-Fd=2"],
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def removeresidual(packages):
         packagelist = packages.split(" ")
-        subprocess.call(["apt", "remove", "--purge", "-yq", "-o", "APT::Status-Fd=2"] + packagelist,
+        subprocess.call(["apt-get", "remove", "--purge", "-yq", "-o", "APT::Status-Fd=2"] + packagelist,
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def removeauto():
-        subprocess.call(["apt", "autoremove", "-yq", "-o", "APT::Status-Fd=2"],
+        subprocess.call(["apt-get", "autoremove", "-yq", "-o", "APT::Status-Fd=2"],
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def externalrepo(keyfile, slistfile):

--- a/src/AutoAptUpdate.py
+++ b/src/AutoAptUpdate.py
@@ -17,7 +17,7 @@ def main():
         cache.update()
     except Exception as e:
         print(str(e))
-        subprocess.call(["apt", "update"],
+        subprocess.call(["apt-get", "update"],
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
 

--- a/src/SysActions.py
+++ b/src/SysActions.py
@@ -28,11 +28,11 @@ def main():
             subupdate()
 
     def subupdate():
-        subprocess.call(["apt", "update"],
+        subprocess.call(["apt-get", "update"],
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def fixbroken():
-        subprocess.call(["apt", "install", "--fix-broken", "-yq"],
+        subprocess.call(["apt-get", "install", "--fix-broken", "-yq"],
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def dpkgconfigure():
@@ -40,7 +40,7 @@ def main():
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def aptclean():
-        subprocess.call(["apt", "clean"],
+        subprocess.call(["apt-get", "clean"],
                         env={**os.environ, 'DEBIAN_FRONTEND': 'noninteractive'})
 
     def externalrepo(key, sources, name):


### PR DESCRIPTION
Use apt-get instead of apt in back-end. This will resolve the "WARNING: apt does not have a stable CLI interface. Use with caution in scripts." error.

This warning can be seen when pardus-software runs at terminal and installing or removing something.

![pardus-software-apt](https://user-images.githubusercontent.com/93371114/218319830-91bac3b1-de32-4772-b5cc-082acd8cd5d9.png)
