### PR TITLE
Failure to open the application if the MAC address is not detected

### DIFF
--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -778,7 +778,8 @@ class MainWindow(object):
         default_gateways = gateway_info['default']
         for family in default_gateways:
             interface = default_gateways[family][1]  # 0 for gateway, 1 for interface
-            mac = netifaces.ifaddresses(interface)[netifaces.AF_LINK][0]["addr"].upper()
+            if AF_LINK in netifaces.ifaddresses(interface):
+                mac = netifaces.ifaddresses(interface)[netifaces.AF_LINK][0]["addr"].upper()
             break
         if mac is None or mac == "":
             print("mac address can not get from netifaces, trying psutil")


### PR DESCRIPTION
Point-to-point connections do not contain a MAC address. Application initially tries to get the MAC address with `netifaces`. For this reason, the application cannot be opened while on a point-to-point connection (for example on a VPN connection). this PR solves this problem via checking if the default gateway has a proper MAC address.

Problem:
https://user-images.githubusercontent.com/94538585/227930699-0b53da4a-a3e2-4c18-978f-b21774213e79.mp4