### PR TITLE
fix: correct notification headers on KDE Plasma

### DIFF
--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -4789,7 +4789,7 @@ class MainWindow(object):
                 Notify.uninit()
 
             if message_summary == "" and message_body == "":
-                Notify.init(self.inprogress_app_name)
+                Notify.init(_("Pardus Software Center"))
                 if self.isinstalled:
                     notification = Notify.Notification.new("{} {}".format(
                         self.get_pretty_name_from_app_name(self.inprogress_app_name),_("Updated") if self.isupgrade else _("Removed")))
@@ -4804,7 +4804,7 @@ class MainWindow(object):
                 except Exception as e:
                     self.Logger.exception("{}".format(e))
             else:
-                Notify.init(message_summary)
+                Notify.init(_("Pardus Software Center"))
                 notification = Notify.Notification.new(message_summary, message_body, "pardus-software")
             notification.show()
         except Exception as e:


### PR DESCRIPTION
## Fixing The App Notifications on KDE Plasma

### Issue

On KDE, `libnotify` displays the `app-name` parameter of `Notify.init()` directly in the notification header. In previous uses of this function, the parameter was given as `app name` or `message_summary`. Because of this, the notifications werent displayed properly on KDE.

So i changed the Notify.init() calls to have the applications name, using the po translations.

| Before | After |
|--------|-------|
|<img width="351" height="102" alt="WhatsApp Image 2026-06-15 at 14 51 24" src="https://github.com/user-attachments/assets/5eff39de-15d6-4959-b3da-aa337a273acd" />|<img width="359" height="105" alt="WhatsApp Image 2026-06-15 at 16 32 45" src="https://github.com/user-attachments/assets/2a5df8f3-2393-4ed9-a620-f0c9680902cd" />|


### Testing the PR

After the fix, i have tested this PR on both GNOME and XFCE desktop envrionments. Everything was working as expected.

| GNOME | XFCE |
|--------|--------|
|<img width="533" height="99" alt="WhatsApp Image 2026-06-15 at 15 46 28" src="https://github.com/user-attachments/assets/522ab00f-947f-4d15-9fcb-28e5a12fd50d" />|<img width="283" height="85" alt="WhatsApp Image 2026-06-15 at 15 43 30" src="https://github.com/user-attachments/assets/9aa2dc5b-f3cf-4c84-acfc-4af30b704659" />|