### PR TITLE
fix: make home page section headings translatable

### DIFF
--- a/po/tr.po
+++ b/po/tr.po
@@ -877,6 +877,24 @@ msgstr "Hata."
 msgid "Process completed."
 msgstr "İşlem tamamlandı."
 
+#. Home page section heading. Keep the <span> and <b> markup, translate only
+#. the text inside.
+#: ui/MainWindow.glade:4019
+msgid "<span size='large'><b>Trending Apps</b></span>"
+msgstr "<span size='large'><b>Yükselen Uygulamalar</b></span>"
+
+#. Home page section heading. Keep the <span> and <b> markup, translate only
+#. the text inside.
+#: ui/MainWindow.glade:4106
+msgid "<span size='large'><b>Most Downloaded Apps</b></span>"
+msgstr "<span size='large'><b>En Çok İndirilenler</b></span>"
+
+#. Home page section heading. Keep the <span> and <b> markup, translate only
+#. the text inside.
+#: ui/MainWindow.glade:4193
+msgid "<span size='large'><b>Recent Apps</b></span>"
+msgstr "<span size='large'><b>Son Eklenen Uygulamalar</b></span>"
+
 #~ msgid "Package is broken."
 #~ msgstr "Paket bozuk."
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -887,7 +887,7 @@ msgstr "<span size='large'><b>Yükselen Uygulamalar</b></span>"
 #. the text inside.
 #: ui/MainWindow.glade:4106
 msgid "<span size='large'><b>Most Downloaded Apps</b></span>"
-msgstr "<span size='large'><b>En Çok İndirilenler</b></span>"
+msgstr "<span size='large'><b>En Çok İndirilen Uygulamalar</b></span>"
 
 #. Home page section heading. Keep the <span> and <b> markup, translate only
 #. the text inside.

--- a/ui/MainWindow.glade
+++ b/ui/MainWindow.glade
@@ -4016,7 +4016,7 @@ The application may have been installed using tools such as Flatpak, Snap, or Wi
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
                                                         <property name="margin-start">8</property>
-                                                        <property name="label">&lt;span size='large'&gt;&lt;b&gt;Trending Apps&lt;/b&gt;&lt;/span&gt;</property>
+                                                        <property name="label" translatable="yes" comments="Home page section heading. Keep the &lt;span&gt; and &lt;b&gt; markup, translate only the text inside.">&lt;span size='large'&gt;&lt;b&gt;Trending Apps&lt;/b&gt;&lt;/span&gt;</property>
                                                         <property name="use-markup">True</property>
                                                       </object>
                                                       <packing>
@@ -4103,7 +4103,7 @@ The application may have been installed using tools such as Flatpak, Snap, or Wi
                                                       <object class="GtkLabel">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="label">&lt;span size='large'&gt;&lt;b&gt;Most Downloaded Apps&lt;/b&gt;&lt;/span&gt;</property>
+                                                        <property name="label" translatable="yes" comments="Home page section heading. Keep the &lt;span&gt; and &lt;b&gt; markup, translate only the text inside.">&lt;span size='large'&gt;&lt;b&gt;Most Downloaded Apps&lt;/b&gt;&lt;/span&gt;</property>
                                                         <property name="use-markup">True</property>
                                                       </object>
                                                       <packing>
@@ -4190,7 +4190,7 @@ The application may have been installed using tools such as Flatpak, Snap, or Wi
                                                       <object class="GtkLabel">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="label">&lt;span size='large'&gt;&lt;b&gt;Recent Apps&lt;/b&gt;&lt;/span&gt;</property>
+                                                        <property name="label" translatable="yes" comments="Home page section heading. Keep the &lt;span&gt; and &lt;b&gt; markup, translate only the text inside.">&lt;span size='large'&gt;&lt;b&gt;Recent Apps&lt;/b&gt;&lt;/span&gt;</property>
                                                         <property name="use-markup">True</property>
                                                       </object>
                                                       <packing>


### PR DESCRIPTION
The "Trending Apps", "Most Downloaded Apps" and "Recent Apps" headings on
the home page were missing the translatable="yes" attribute, so they never
entered the translation catalog. The labels also have no widget id, which
means they cannot be set from Python at runtime either — there was no way
for these strings to appear in the user's language.

The same strings are already translated where they appear in the sidebar
(ui/MainWindow.glade:676 and :836), so a Turkish user currently sees
"Yükselen Uygulamalar" in the sidebar and "Trending Apps" as the heading
of the very list it opens.

Mark the three properties translatable and add the Turkish translations,
reusing the existing sidebar wording. Markup is kept inside the msgid,
matching the convention already used for headings such as
"<span size='large'><b>All Apps</b></span>". A translator comment asks
translators to preserve the markup.

Other locales (pt, es) need `msgmerge` to pick up the new strings; only
tr.po is filled in here.
